### PR TITLE
feat(demo): make demo mode a write-safe shell over every feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ Transactions are built in `src/services/txServices.ts` using `@stacks/transactio
 
 ### Demo Mode
 
-`?demo=true` activates demo mode with a hardcoded address. All write operations must be no-ops in demo — do not call signing or broadcast APIs. Gate mutation entrypoints on `useDemoMode()`.
+`?demo=true` activates demo mode with a hardcoded address. All write operations are no-ops — `useTxServices` short-circuits every mutation (`sendTransaction`, `callExtensionContract`, `deployContract`, `addAdmin`, `transferOwnership`, `deposit`) and returns a fake tx receipt with a "Demo mode" toast, never reaching `@stacks/connect`. Read paths swap real services for `Mock*` variants in `useSmartWalletContractService` / `useAccountBalanceService` (gated on `useDemoMode().isDemoMode` — note the destructure: the hook returns the full context object).
+
+If you add a new mutation, route it through `useTxServices` so the demo gate stays a single chokepoint.
 
 ### Contracts
 

--- a/src/hooks/useAccountBalanceService.tsx
+++ b/src/hooks/useAccountBalanceService.tsx
@@ -17,7 +17,7 @@ export function useAccountBalanceService(walletAddress: string) {
   const [sBtcBalance, setSBtcBalance] = useState<FungibleType | null>(null);
 
   // Check if we're in demo mode
-  const isDemoMode = useDemoMode();
+  const { isDemoMode } = useDemoMode();
 
   // Select the appropriate service based on demo mode
   const balancesService = useMemo(() => {

--- a/src/hooks/useSmartWalletContractService.ts
+++ b/src/hooks/useSmartWalletContractService.ts
@@ -19,7 +19,7 @@ export const useSmartWalletContractService = (walletAddress?: string) => {
   const [error, setError] = useState<string | null>(null);
 
   // Check if we're in demo mode
-  const isDemoMode = useDemoMode();
+  const { isDemoMode } = useDemoMode();
 
   // Select the appropriate service based on demo mode
   const smartWalletService = useMemo(() => {

--- a/src/hooks/useTxServices.ts
+++ b/src/hooks/useTxServices.ts
@@ -1,4 +1,5 @@
 import { useToast } from "@/hooks/use-toast";
+import { useDemoMode } from "@/contexts";
 import {
   ExtensionCallParams,
   TransactionParams,
@@ -6,6 +7,13 @@ import {
 } from "@/services/txServices";
 import { TransactionResult } from "@stacks/connect/dist/types/methods";
 import { useCallback, useState } from "react";
+
+const DEMO_TXID =
+  "0xdemo00000000000000000000000000000000000000000000000000000000demo";
+
+const demoResult = (): TransactionResult => ({
+  txid: DEMO_TXID,
+} as TransactionResult);
 
 /**
  * Custom hook for managing transaction services
@@ -15,14 +23,30 @@ export const useTxServices = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { toast } = useToast();
+  const { isDemoMode } = useDemoMode();
 
   const txServices = new TxServices();
+
+  // In demo mode, surface a toast and short-circuit before touching the
+  // wallet extension. Mutations resolve to a fake tx receipt so downstream
+  // success handlers (navigation, optimistic UI) still run.
+  const demoNoop = useCallback(
+    <T>(action: string, fakeResult: T): T => {
+      toast({
+        title: "Demo mode",
+        description: `${action} is disabled — no transaction was broadcast.`,
+      });
+      return fakeResult;
+    },
+    [toast]
+  );
 
   /**
    * Send a transaction (token or NFT)
    */
   const sendTransaction = useCallback(
     async (params: TransactionParams): Promise<TransactionResult | null> => {
+      if (isDemoMode) return demoNoop("Send", demoResult());
       setIsLoading(true);
       setError(null);
 
@@ -51,7 +75,7 @@ export const useTxServices = () => {
         setIsLoading(false);
       }
     },
-    [toast]
+    [toast, isDemoMode, demoNoop]
   );
 
   /**
@@ -62,6 +86,10 @@ export const useTxServices = () => {
       walletId: `${string}.${string}`,
       params: ExtensionCallParams
     ): Promise<void | null> => {
+      if (isDemoMode) {
+        demoNoop("Extension call", undefined);
+        return;
+      }
       setIsLoading(true);
       setError(null);
       try {
@@ -91,7 +119,7 @@ export const useTxServices = () => {
         setIsLoading(false);
       }
     },
-    [toast]
+    [toast, isDemoMode, demoNoop]
   );
 
   /**
@@ -99,6 +127,10 @@ export const useTxServices = () => {
    */
   const deployContract = useCallback(
     async (params: any): Promise<void | null> => {
+      if (isDemoMode) {
+        demoNoop("Contract deploy", undefined);
+        return;
+      }
       setIsLoading(true);
       setError(null);
 
@@ -127,7 +159,7 @@ export const useTxServices = () => {
         setIsLoading(false);
       }
     },
-    [toast]
+    [toast, isDemoMode, demoNoop]
   );
 
   /**
@@ -138,6 +170,7 @@ export const useTxServices = () => {
       contractAddress: string;
       adminAddress: string;
     }): Promise<TransactionResult | null> => {
+      if (isDemoMode) return demoNoop("Add admin", demoResult());
       setIsLoading(true);
       setError(null);
 
@@ -166,7 +199,7 @@ export const useTxServices = () => {
         setIsLoading(false);
       }
     },
-    [toast]
+    [toast, isDemoMode, demoNoop]
   );
 
   /**
@@ -177,6 +210,7 @@ export const useTxServices = () => {
       contractAddress: string;
       newOwnerAddress: string;
     }): Promise<TransactionResult | null> => {
+      if (isDemoMode) return demoNoop("Transfer ownership", demoResult());
       setIsLoading(true);
       setError(null);
 
@@ -207,7 +241,7 @@ export const useTxServices = () => {
         setIsLoading(false);
       }
     },
-    [toast]
+    [toast, isDemoMode, demoNoop]
   );
 
   /**
@@ -224,6 +258,7 @@ export const useTxServices = () => {
       contractAddress?: string;
       decimal: number;
     }): Promise<{ txid: string } | null> => {
+      if (isDemoMode) return demoNoop("Deposit", { txid: DEMO_TXID });
       setIsLoading(true);
       setError(null);
       try {
@@ -251,7 +286,7 @@ export const useTxServices = () => {
         setIsLoading(false);
       }
     },
-    [toast]
+    [toast, isDemoMode, demoNoop]
   );
 
   /**
@@ -259,6 +294,7 @@ export const useTxServices = () => {
    */
   const isAdmin = useCallback(
     async (address: string, contractId: string): Promise<boolean> => {
+      if (isDemoMode) return true;
       try {
         const result = await txServices.isAdmin(address, contractId);
         return result;
@@ -266,7 +302,7 @@ export const useTxServices = () => {
         return false;
       }
     },
-    []
+    [isDemoMode]
   );
 
   /**


### PR DESCRIPTION
Stacked on #3 (tailwind/noble). Targets that branch on the openintents fork; once the chain merges, retarget to upstream `dev`.

## Summary
Make demo mode (`?demo=true`) a stable, write-safe shell across the whole app — no signing prompts, no wallet broadcasts, no errors when poking around without a wallet.

### Mutation gating
`useTxServices` is the single chokepoint every UI mutation routes through. Each method now:
- checks `isDemoMode` first
- toasts "Demo mode — no transaction was broadcast"
- returns a fake tx receipt (`txid: 0xdemo...`) so downstream success handlers (toasts, navigation, optimistic state) still run

Covers all 6 mutations: `sendTransaction`, `callExtensionContract`, `deployContract`, `addAdmin`, `transferOwnership`, `deposit`. `isAdmin` returns `true` in demo so admin-gated screens render.

### Latent bug fix
`useSmartWalletContractService` and `useAccountBalanceService` were doing `const isDemoMode = useDemoMode()` — but the hook returns the full context object, which is always truthy. So mock services were active any time the provider mounted, regardless of the URL flag. Switched to `const { isDemoMode } = useDemoMode()`.

### Docs
`CLAUDE.md` now documents the chokepoint pattern so future mutations preserve the invariant.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run test --run` (6 pre-existing failures, no new ones)
- [ ] `?demo=true` → click Send / Deposit / Delegate / Add Admin / Transfer Ownership / Deploy → each shows the "Demo mode" toast and never opens the wallet extension
- [ ] Without `?demo=true` (real wallet connected), normal flows still prompt the wallet
- [ ] Toggle demo mode off mid-session → next action prompts the wallet again

🤖 Generated with [Claude Code](https://claude.com/claude-code)