### PR TITLE
feat: contract identicons + SIP draft

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@noble/hashes": "^2.2.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",
@@ -57,6 +58,7 @@
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^1.8.0",
+    "minidenticons": "^4.2.1",
     "next-themes": "^0.4.6",
     "react": "^19.2.5",
     "react-day-picker": "^9.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -137,6 +140,9 @@ importers:
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
+      minidenticons:
+        specifier: ^4.2.1
+        version: 4.2.1
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3314,6 +3320,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  minidenticons@4.2.1:
+    resolution: {integrity: sha512-oWfFivA0lOx/V/bO/YIJbthB26lV8JXYvhnv9zM2hNd3fzsHTXQ6c6bWZPcvhD3nnOB+lQk/D9lF43BXixrN8g==}
+    engines: {node: '>=15.14.0'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -4858,8 +4868,7 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@noble/hashes@2.2.0':
-    optional: true
+  '@noble/hashes@2.2.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -7070,7 +7079,7 @@ snapshots:
 
   c32check@2.0.0:
     dependencies:
-      '@noble/hashes': 1.1.5
+      '@noble/hashes': 1.8.0
       base-x: 4.0.1
 
   call-bind-apply-helpers@1.0.2:
@@ -8005,6 +8014,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  minidenticons@4.2.1: {}
 
   minimalistic-assert@1.0.1:
     optional: true

--- a/sips/sip-xxx-contract-identicons.md
+++ b/sips/sip-xxx-contract-identicons.md
@@ -1,0 +1,129 @@
+# Preamble
+
+| SIP Number    | XXX                                                                |
+| ------------- | ------------------------------------------------------------------ |
+| Title         | Contract identicons                                                |
+| Author        | Friedger Müffke \<mail@friedger.de\>                               |
+| Consideration | Technical                                                          |
+| Type          | Standard                                                           |
+| Status        | Draft                                                              |
+| Created       | 2026-04-13                                                         |
+| License       | CC0-1.0                                                            |
+| Discussions-To| https://forum.stacks.org/t/identicon-for-contracts/18637           |
+| Layer         | Traits                                                             |
+
+# Abstract
+
+This SIP specifies a deterministic way to derive a visual identifier (an "identicon") for any Clarity smart contract deployed to the Stacks blockchain. The identicon is a pure function of the contract's source code after canonicalization: two deployments of the same source — on any address, at any height, on any network — render the same icon. Wallets, explorers, and apps that implement the specification allow users to recognize known code at a glance and to notice when contracts that share a name or author address do not share code.
+
+The specification pins three things: the canonical form of the source (the output of `clarinet fmt` with default settings), the hash function (`SHA-512/256` over the UTF-8 bytes of the canonical form), and the rendering library and configuration (`minidenticons`, default options, seeded with the lowercase hex-encoded hash). The output is an SVG suitable for inline rendering.
+
+# Copyright
+
+This SIP is made available under the terms of the Creative Commons CC0 1.0 Universal license, available at https://creativecommons.org/publicdomain/zero/1.0/.
+
+# Introduction
+
+Clarity contracts are addressed by `{deployer}.{name}`. That pair is useful for on-chain references but is a poor user-facing identifier: a user reading `SP2J….transfer-helper` cannot tell from the name alone whether this is the audited, widely-deployed helper they have used before, a fork with a subtle change, or a phishing lookalike deployed to a confusable address.
+
+Hash-based identicons are a well-understood solution to this problem (see `identicon`, `jdenticon`, `blockies`, the GitHub default avatar). What is missing on Stacks is a consensus on *which* bytes get hashed and *which* renderer is used, so that the same contract produces the same icon everywhere it is shown.
+
+This SIP proposes that consensus. It does not propose any consensus change to the Stacks blockchain — the specification is an off-chain convention followed by wallets, explorers, and apps. A contract may optionally expose a read-only `get-identicon-hash` function as a self-declaration (see [Reference Implementations](#reference-implementations)), but the canonical source of truth is always the deployed source code.
+
+# Specification
+
+## 1. Canonical source
+
+The canonical form of a contract's source code is the **byte-for-byte output of `clarinet fmt` invoked with default settings, version 3 or later**, against the contract's `.clar` source file.
+
+- Formatters MUST normalize line endings to `\n` (LF).
+- Formatters MUST produce a final trailing `\n`.
+- Comments (`;;` and `;;;`) are part of the source and are preserved by `clarinet fmt`. They are hashed.
+- The canonical form is UTF-8 encoded; no BOM.
+
+Implementations that do not have access to a Clarinet formatter (for example, browser-only apps fetching source from `/v2/contracts/source`) SHOULD hash the source as returned by the node, assuming the contract author deployed `clarinet fmt`-formatted source. Implementations MAY display a "source not canonicalized" warning next to the identicon when the returned source deviates from a heuristic check (trailing whitespace, mixed line endings, tabs mixed with spaces).
+
+Contract authors who wish to participate in the identicon convention MUST run `clarinet fmt` before deploying. Two authors deploying identical logic with different whitespace will produce different identicons; this is a feature, not a bug, because the bytes that reach the blockchain differ.
+
+## 2. Hash
+
+The identicon hash is:
+
+```
+identicon_hash = SHA-512/256(utf8_bytes(canonical_source))
+```
+
+- `SHA-512/256` is the SHA-512 algorithm with the 512/256 initialization vector, truncated to 256 bits (FIPS 180-4 §5.3.6).
+- The output is a 32-byte buffer.
+- When passed to the renderer, the hash is lowercase hex-encoded without a `0x` prefix (64 characters).
+
+This is the same hash exposed in Clarity as the `sha512/256` function, so a contract MAY compute and expose its own identicon hash on-chain:
+
+```clarity
+(define-read-only (get-identicon-hash (source (buff 65535)))
+  (sha512/256 source))
+```
+
+Off-chain implementations MUST NOT rely on any on-chain value; the hash is always derived from the deployed source.
+
+## 3. Rendering
+
+The identicon is rendered with the **`minidenticons`** library, used in its default configuration:
+
+- Library: `minidenticons` (https://github.com/laurentpayot/minidenticons), version 4.x or later.
+- Function: `minidenticonSvg(seed, saturation, lightness)`.
+- Arguments:
+  - `seed`: the lowercase hex-encoded identicon hash from §2.
+  - `saturation`: default (`50`).
+  - `lightness`: default (`50`).
+- Output: an SVG string, 5×5 symmetric grid.
+
+Implementations MAY override saturation and lightness to match their theme, but the seed MUST remain the hex-encoded hash so the grid pattern stays constant. A light and a dark theme that agree on the seed will display the same silhouette in different colors, which is the intended behavior.
+
+## 4. Contract ID display
+
+When space permits, implementations SHOULD display the identicon adjacent to the contract principal (`{deployer}.{name}`). The identicon is advisory: it supplements, not replaces, the full principal.
+
+## 5. Network isolation
+
+Identicons are a function of source code only, not of network. A contract deployed on testnet and mainnet from identical formatted source will render the same icon. Implementations SHOULD label the network separately.
+
+# Related Work
+
+- **Ethereum Blockies** (`ethereum-blockies`): hashes the lowercase hex address, not the bytecode. Identical code at different addresses renders differently — the opposite trade-off from this SIP.
+- **Jdenticon**: another open-source identicon library. Produces ~874k distinct icons (vs. ~295k for minidenticons). A future revision of this SIP MAY switch renderers; the hash specification is independent of the renderer.
+- **Sourcify**: verifies EVM contract source against deployed bytecode. Useful precedent for canonical-source conventions. This SIP intentionally skips the verification step because Stacks deploys source directly, not bytecode.
+- **SHA-256 of raw source bytes**: simpler, but does not de-duplicate trivially equivalent sources (a single trailing newline would change the icon).
+
+# Backwards Compatibility
+
+This is a new off-chain convention. There is no on-chain consensus change and no breaking impact on existing contracts, wallets, or explorers. Implementations that do not adopt the SIP continue to display contracts as before.
+
+# Activation
+
+This SIP activates once ratified by the usual SIP process. Reference implementations below may ship ahead of ratification as `Draft`-tagged previews. Wallets and explorers adopting the draft SHOULD clearly mark the feature as a preview until the SIP reaches `Ratified` status, because a late change to the hash or renderer choice would invalidate cached icons.
+
+# Reference Implementations
+
+## TypeScript / browser
+
+A reference implementation lives in this repository at `src/utils/contractIdenticon.ts` and is wired into the wallet selector at `src/components/wallet-selector/WalletCard.tsx`. The module:
+
+1. fetches contract source via `GET /v2/contracts/source/{address}/{name}` against the appropriate Hiro API host for the network;
+2. hashes the returned source with `sha512_256` from `@noble/hashes/sha2`;
+3. renders via `minidenticonSvg` from the `minidenticons` package.
+
+Canonicalization via `clarinet fmt` is not performed in the browser implementation; see §1 on assumptions and heuristic warnings.
+
+## Clarity (self-declaration)
+
+```clarity
+(define-read-only (identicon-hash (source (buff 65535)))
+  (sha512/256 source))
+```
+
+A contract MAY call this off-chain to emit its own hash as an event for indexers that prefer to read the hash rather than recompute it.
+
+# Sign-off
+
+_To be completed at ratification._

--- a/src/components/ContractIdenticon.tsx
+++ b/src/components/ContractIdenticon.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import {
+  ContractId,
+  contractIdenticonSvg,
+} from "@/utils/contractIdenticon";
+
+interface ContractIdenticonProps {
+  contractId: ContractId;
+  size?: number;
+  className?: string;
+}
+
+export const ContractIdenticon = ({
+  contractId,
+  size = 32,
+  className,
+}: ContractIdenticonProps) => {
+  const [svg, setSvg] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    contractIdenticonSvg(contractId)
+      .then(({ svg }) => {
+        if (!cancelled) setSvg(svg);
+      })
+      .catch(() => {
+        if (!cancelled) setSvg(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId]);
+
+  if (!svg) {
+    return (
+      <div
+        className={className}
+        style={{ width: size, height: size }}
+        aria-hidden
+      />
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={`Identicon for ${contractId}`}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+};
+
+export default ContractIdenticon;

--- a/src/components/wallet-selector/WalletCard.tsx
+++ b/src/components/wallet-selector/WalletCard.tsx
@@ -1,8 +1,10 @@
 import { Link, useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Wallet, Settings, CopyIcon } from "lucide-react";
+import { Settings, CopyIcon } from "lucide-react";
 import GreenButton from "../ui/green-button";
+import ContractIdenticon from "@/components/ContractIdenticon";
+import type { ContractId } from "@/utils/contractIdenticon";
 import { SmartWallet } from "@/services/interfaces";
 import { useState } from "react";
 import { useAccountBalanceService } from "@/hooks/useAccountBalanceService";
@@ -39,7 +41,11 @@ const WalletCard = ({ wallet }: WalletCardProps) => {
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-white flex items-center">
-            <Wallet className="mr-2 h-5 w-5 text-purple-400" />
+            <ContractIdenticon
+              contractId={wallet.contractId as ContractId}
+              size={20}
+              className="mr-2"
+            />
             {wallet?.label}
             {wallet.ext && (
               <span className="ml-2 px-2 py-1 bg-blue-600/20 text-blue-300 text-xs rounded">

--- a/src/utils/contractIdenticon.ts
+++ b/src/utils/contractIdenticon.ts
@@ -1,0 +1,46 @@
+import { sha512_256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { minidenticonSvg } from "minidenticons";
+import { getClientConfig } from "@/utils/chain-config";
+
+// Reference implementation for SIP-XXX (Contract identicons).
+// See sips/sip-xxx-contract-identicons.md for the full specification.
+//
+// Pipeline:
+//   fetch source -> sha512/256 -> hex seed -> minidenticonSvg
+//
+// Canonicalization via `clarinet fmt` is not performed here; we assume
+// the contract author deployed canonical source. See §1 of the SIP.
+
+export type ContractId = `${string}.${string}`;
+
+export async function fetchContractSource(
+  contractId: ContractId
+): Promise<string> {
+  const [address, name] = contractId.split(".") as [string, string];
+  const { api } = getClientConfig(address);
+  const res = await fetch(`${api}/v2/contracts/source/${address}/${name}`);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch source for ${contractId}: ${res.status} ${res.statusText}`
+    );
+  }
+  const data: { source: string } = await res.json();
+  return data.source;
+}
+
+export function identiconHash(source: string): string {
+  return bytesToHex(sha512_256(new TextEncoder().encode(source)));
+}
+
+export function identiconSvg(seedHex: string): string {
+  return minidenticonSvg(seedHex);
+}
+
+export async function contractIdenticonSvg(
+  contractId: ContractId
+): Promise<{ svg: string; hash: string }> {
+  const source = await fetchContractSource(contractId);
+  const hash = identiconHash(source);
+  return { svg: identiconSvg(hash), hash };
+}


### PR DESCRIPTION
Stacked on #4. Contract identicons to build user trust: wallets and explorers that implement this spec show the same icon for the same contract source, making known code recognizable at a glance.

## SIP draft
`sips/sip-xxx-contract-identicons.md` — full specification. Pins:
- **Canonical form** = output of `clarinet fmt` (default settings).
- **Hash** = SHA-512/256 over UTF-8 bytes (matches Clarity's own `sha512/256` so a contract can self-declare its hash on-chain).
- **Renderer** = `minidenticons` with default options, seeded with lowercase hex.

Includes sections on canonicalization assumptions in browser contexts, related work (blockies / jdenticon / sourcify), backwards compatibility (none — off-chain convention), and the optional on-chain self-declaration pattern.

Forum discussion: https://forum.stacks.org/t/identicon-for-contracts/18637

## Reference implementation
- `src/utils/contractIdenticon.ts`: fetch `/v2/contracts/source/{addr}/{name}` → `sha512_256` from `@noble/hashes/sha2` → `minidenticonSvg`.
- `src/components/ContractIdenticon.tsx`: async SVG component with loading fallback + a11y label.
- Wired into `WalletCard.tsx`, replacing the generic `Wallet` lucide icon with the per-contract identicon.

## Deps
- Adds `minidenticons` (~3 KB).
- Re-adds `@noble/hashes@^2` as a direct dep — the `sha2` subpath isn't available via the 1.x version Stacks libs pull in transitively.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run dev` boots
- [ ] Manual: wallet selector shows distinct icons per wallet; identical contracts (e.g. two deployments of the same standard wallet) show identical icons
- [ ] Network split: mainnet/testnet deployments of the same source render the same icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)